### PR TITLE
태그 추천 및 태그 검색 API 연동

### DIFF
--- a/navigation/RootNavigator.js
+++ b/navigation/RootNavigator.js
@@ -14,7 +14,7 @@ import SwipeScreen from '../src/screens/Swipe/SwipeScreen';
 import CardSettingScreen from '../src/screens/CardSettingScreen';
 import {Switch} from 'react-native-gesture-handler';
 import Carousel from '../src/screens/Swipe/Carousel';
-import ImageModal from '../src/screens/Swipe/ImageModal';
+//import ImageModal from '../src/screens/Swipe/ImageModal';
 const Home = createStackNavigator();
 
 const state = {
@@ -62,7 +62,7 @@ function TabNavigator() {
     <Tab.Navigator>
       <Tab.Screen name="TagSelect" component={TagSelectScreen} />
       <Tab.Screen name="Swipe" component={SwipeScreen} />
-      <Tab.Screen name="ImageModal" component={ImageModal} />
+      {/*<Tab.Screen name="ImageModal" component={ImageModal} />*/}
     </Tab.Navigator>
   );
 }

--- a/src/repos/TagRepository.js
+++ b/src/repos/TagRepository.js
@@ -7,8 +7,12 @@ class TagRepository {
     this.URL = url || this.URL;
   }
   // Todo - userId 값 식별해서 요청 보내기 
-  getTagList() {
+  getTags() {
     return axios.get(this.URL + ':8083/tag/reco?userId=14', {});
+  }
+
+  searchTag(keyword) {
+    return axios.get(this.URL + ":8083/tag/search?keyword=" + keyword + "&userId=14");
   }
 }
 

--- a/src/screens/TagSelect/SearchButton.js
+++ b/src/screens/TagSelect/SearchButton.js
@@ -1,27 +1,32 @@
-import React, {useState} from 'react';
+import React from 'react';
 import {StyleSheet} from 'react-native';
 import {SearchBar} from 'react-native-elements';
 import {} from 'react-native-vector-icons';
 
-const SearchButton = () => {
-  const [searchWord, setSearchWord] = useState('');
+const SearchButton = (props) => {
 
   return (
     <SearchBar
       containerStyle={styles.searchContainer}
       inputContainerStyle={styles.searchInputContainer}
+
       placeholder="Type Here..."
-      onChangeText={value => setSearchWord(value)}
-      value={searchWord}
+      onChangeText={value => props.setSearchWord(value)}
+      onSubmitEditing={props.onSubmit} // props of TextInput, callback when submit button is pressed
+      onClear={props.onClear}
+      
+      value={props.searchWord}
+
+      round={true} // change TextInput styling to rounded corners 
+      showLoading={false}
     />
   );
 };
 
 const styles = StyleSheet.create({
   searchContainer: {
-    marginLeft: 25,
+    marginHorizontal: 25,
     marginTop: 25,
-    width: 255,
     borderRadius: 22,
     backgroundColor: '#ffffff',
     borderStyle: 'solid',
@@ -29,8 +34,8 @@ const styles = StyleSheet.create({
     borderColor: '#707070',
   },
   searchInputContainer: {
-    width: 240,
-    height: 43,
+    width: "95%",
+    height: "5%",
     backgroundColor: '#ffffff',
   },
 });

--- a/src/screens/TagSelect/Tag.js
+++ b/src/screens/TagSelect/Tag.js
@@ -8,15 +8,7 @@ const Tag = ({rowIndex, item}) => {
   return (
     <TouchableOpacity onPress={() => navigation.navigate('Swipe')}>
       <View
-        style={
-          item === 0
-            ? styles.firstRow
-            : item === 1
-            ? styles.secondRow
-            : rowIndex === 1
-            ? styles.firstRow
-            : styles.thirdRow
-        }>
+        style={rowIndex ? styles.secondRow : styles.firstRow}>
         <Image style={styles.img} source={require('../../images/dooboo.jpg')} />
         <Text>{item.name}</Text>
       </View>
@@ -26,10 +18,12 @@ const Tag = ({rowIndex, item}) => {
 
 const styles = StyleSheet.create({
   firstRow: {
-    marginLeft: 50,
+    marginLeft: 30,
+    alignItems: "center",
   },
   secondRow: {
     marginLeft: 100,
+    alignItems: "center"
   },
   secondColumnText: {
     fontSize: 20,

--- a/src/screens/TagSelect/TagColumn.js
+++ b/src/screens/TagSelect/TagColumn.js
@@ -6,7 +6,7 @@ const TagColumn = ({item, idx}) => {
   return (
     <View styles={styles.rows}>
       <Tag rowIndex={0} item={item[0]} />
-      <Tag rowIndex={1} item={item[1]} />
+      {item[1] && <Tag rowIndex={1} item={item[1]} />}
     </View>
   );
 };

--- a/src/screens/TagSelect/TagSelectScreen.js
+++ b/src/screens/TagSelect/TagSelectScreen.js
@@ -1,23 +1,16 @@
-import React, { useEffect } from 'react';
-import {FlatList, StyleSheet, Text, View} from 'react-native';
+import React, { useState, useEffect } from 'react';
+import {FlatList, StyleSheet, Text, View, Button} from 'react-native';
 import TagColumn from './TagColumn';
 import SearchButton from './SearchButton';
 import {TouchableOpacity} from 'react-native-gesture-handler';
 import {inject, observer} from 'mobx-react';
 
-//let list = [];
-
-/*for (let i = 0; i < 50; i++) {
-  list.push({'idx': i, 'tag' : "태그"});
-}*/
-
-
-
 const TagSelectScreen = ({tagStore}) => {
   const tags = [];
+  const [searchWord, setSearchWord] = useState('');
 
   useEffect(() => {
-    tagStore.getItem();
+    tagStore.getTags();
   }, []);
 
   let list = tagStore.tagList;
@@ -34,10 +27,21 @@ const TagSelectScreen = ({tagStore}) => {
     return <TagColumn item={item} />;
   };
 
+  const onSubmitSearchWord = () => {
+    console.log("tagSelectScreen", searchWord);
+    tagStore.searchTag(searchWord);
+  }
+
   return (
     <>
-      <SearchButton />
-      <FlatList
+      <SearchButton 
+        searchWord={searchWord} 
+        setSearchWord={setSearchWord}
+        onSubmit={onSubmitSearchWord}
+        onClear={() => tagStore.getTags()}/>
+      {list.length === 0
+      ? <View style={styles.textContainer}><Text>검색어와 일치하는 태그가 없습니다.</Text></View>
+      : <FlatList
         horizontal={true}
         contentContainerStyle={styles.flatListContainer}
         data={tags}
@@ -45,7 +49,7 @@ const TagSelectScreen = ({tagStore}) => {
         renderItem={renderColumn}
         showsHorizontalScrollIndicator={true}
         indicatorStyle="white"
-      />
+      />}
       <View style={styles.buttonView}>
         <TouchableOpacity style={styles.button}>
           <Text style={styles.buttonText}>태그선택완료</Text>
@@ -77,14 +81,22 @@ const styles = StyleSheet.create({
     borderColor: 'gray',
     borderRadius: 50,
     borderWidth: 1,
+
     justifyContent: 'center',
     alignItems: 'center',
     width: 200,
     height: 50,
+
+    marginBottom: 25,
   },
   buttonText: {
     color: 'black',
   },
+  textContainer:{
+    flexGrow: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  }
 });
 
 export default inject("tagStore") (observer (TagSelectScreen));

--- a/src/stores/Tag.js
+++ b/src/stores/Tag.js
@@ -14,15 +14,31 @@ class tagStore {
 
   // Todo 2. API 연결해서 Tag List 받아오기
   @action 
-  async getItem() {
+  async getTags() {
     let response;
     try {
-      response = await tagRepository.getTagList();
+      response = await tagRepository.getTags();
     } catch (error) {
       console.log(error);
     }
     const data = response.data;
-    this.tagList = data.map(tag => new tagModel(tag));
+    if(response.headers["user-type"] === "initial"){
+      this.tagList = [{embedding: null, id: 0, name: "랜덤 추천"}]
+    }
+    else if(response.headers["user-type"] === "pass"){
+      this.tagList = data.map(tag => new tagModel(tag));
+    }
+  }
+
+  @action
+  async searchTag(searchWord) {
+    let response;
+    try{
+      response = await tagRepository.searchTag(searchWord);
+    } catch (error) {
+      console.log(error);
+    }
+    this.tagList = response.data;
   }
 }
 


### PR DESCRIPTION
### What
태그 추천 API 와 태그 검색 API 연동했습니다.

### How
태그 추천 tagStore 에서 response headers 에 담긴 user-type 값을 확인 (검색 시에도 해야 하나 현재는 막아두지 않음)
SearchButton 컴포넌트에 있던 searchWord state 를 TagSelectScreen state 로 변경하고, SearchButton 컴포넌트에 props 를 전달
SearchBar 에 onSubmitEditing(input submit 시) onClear(input clear 시)를 추가하고, 검색 시 tagStore 의 searchTag 함수를 호출해 서버와 통신.
검색어와 일치하는 태그가 없는 경우 Text 를 보여줌